### PR TITLE
feat: split workflows into multiples workflows

### DIFF
--- a/.github/workflow-templates/release-app.properties.json
+++ b/.github/workflow-templates/release-app.properties.json
@@ -1,0 +1,10 @@
+{
+    "name": "Tag - Build - Release application",
+    "description": "Feedgy default release application workflow.",
+    "creator": "Feedgy",
+    "categories": [
+        "Continuous integration",
+        "Deployment",
+        "Dockerfile"
+    ]
+}

--- a/.github/workflow-templates/release-app.yml
+++ b/.github/workflow-templates/release-app.yml
@@ -1,0 +1,66 @@
+name: release-app
+
+env:
+    INFRA_REPO: url-to-infra-repo
+    APP_NAME: your-arog-cd-app
+    IMAGE_NAME: ${{ github.repository }}
+    USERNAME: ${{ github.actor }}
+    BRANCH: ${{ github.ref_name }}
+
+on:
+    # Triggers the workflow on push for the release branches
+    push:
+        branches: [ staging, production ]
+    # Can release manually (for test with dry-run enabled)
+    workflow_dispatch:
+        inputs:
+            dry-run:
+                description: 'dry run'
+                type: boolean
+                required: false
+
+jobs:
+    tag:
+        uses: feedgy/templates/.github/workflows/tag.yml@main
+        with:
+            dry_run: ${{ github.event.inputs.dry-run }}
+        #   optional: (w default)
+        #    pre_release_branches: staging
+        #    release_branches: production
+        secrets:
+            repos_token: ${{ secrets.ACCESS_TOKEN }}
+    build:
+        uses: feedgy/templates/.github/workflows/build-docker.yml@main
+        needs:
+            - tag
+        with:
+            image_name: ${{ github.repository }}
+            username: ${{ env.USERNAME }}
+            branch: ${{ env.BRANCH }}
+            tag: ${{ needs.tag.new_tag }}
+            dry_run: ${{ inputs.dry_run }}
+        #   optional: (w default)
+        #    docker_context: .
+        #    docker_build_args: (None)
+        #    dockerfile_path: ./Dockerfile
+        secrets:
+            registry_token: ${{ secrets.GITHUB_TOKEN }}
+    deploy-and-release:
+        uses: feedgy/templates/.github/workflows/deploy-app.yml@main
+        needs:
+            - tag
+            - build
+        with:
+            app_name: ${{ env.APP_NAME }}
+            image_name: ${{ env.IMAGE_NAME }}
+            username: ${{ env.USERNAME }}
+            branch: ${{ env.BRANCH  }}
+            infra_repository: ${{ env.INFRA_REPO }}
+            tag: ${{ needs.build.outputs.tag }}
+            changelog: ${{ needs.tag.outputs.changelog }}
+        #   optional: (w default)
+        #    infra_main_branch: master
+        #    push_name: 'Super Bot'
+        #    push_mail: 'bot@feedgy.solar'
+        secrets:
+            repos_token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,112 @@
+name: build-docker
+
+# configure as reusable workflow
+on:
+    workflow_call:
+        inputs:
+            registry:
+                required: false
+                type: string
+                default: 'ghcr.io'
+                description: 'registry to push and get the image'
+            image_name:
+                required: true
+                type: string
+                description: 'name of the image'
+            docker_context:
+                required: false
+                type: string
+                default: .
+                description: 'context of build for docker'
+            docker_build_args:
+                required: false
+                type: string
+                description: 'docker build args formated in multiline string with |'
+            dockerfile_path:
+                required: false
+                type: string
+                default: ./Dockerfile
+                description: 'location to get the Dockerfile for the build'
+            username:
+                required: true
+                type: string
+                description: 'username to push the image can use github.actor'
+            branch:
+                required: true
+                type: string
+                description: 'name of the branch can use github.ref_name'
+            tag:
+                required: true
+                type: string
+                description: 'tag to push the image with'
+            dry_run:
+                required: false
+                type: boolean
+                default: false
+                description: 'build only with the new version of tag'
+        secrets:
+            registry_token:
+                required: true
+                description: 'token to have access to registry'
+        outputs:
+            pushed_tag: ${{ jobs.tag.outputs.pushed_tag }}
+
+jobs:
+    deploy-docker:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        outputs:
+            pushed_tag: ${{ inputs.tag }}
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v2
+
+            -   id: image_registry_lower
+                uses: ASzc/change-string-case-action@v2
+                with:
+                    string: ${{ inputs.registry }}/${{ inputs.IMAGE_NAME }}
+            # Set docker driver to permit cache
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v1
+                with:
+                    driver: docker-container
+                    driver-opts: |
+                        image=moby/buildkit:master
+                        network=host
+            # Login against a Docker registry except on PR
+            # https://github.com/docker/login-action
+            -   name: Log into registry ${{ inputs.registry }}
+                if: github.event_name != 'pull_request'
+                uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+                with:
+                    registry: ${{ inputs.registry }}
+                    username: ${{ inputs.username }}
+                    password: ${{ secrets.registry_token }}
+
+            # Extract metadata (tags, labels) for Docker
+            # https://github.com/docker/metadata-action
+            -   name: Extract Docker metadata
+                id: meta
+                uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681
+                with:
+                    github-token: ${{ secrets.registry_token }}
+                    images: ${{ steps.image_registry_lower.outputs.lowercase }}
+                    tags: |
+                        type=semver, pattern={{raw}}, value=${{ inputs.tag }}
+                        type=ref, event=branch
+            # Build and push Docker image with Buildx (don't push on PR)
+            # https://github.com/docker/build-push-action
+            -   name: Build and push Docker image
+                uses: docker/build-push-action@v2
+                id: build
+                with:
+                    context: ${{ inputs.docker_context }}
+                    push: ${{ inputs.dry_run == false }}
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
+                    file: ${{ inputs.dockerfile_path }}
+                    cache-from: type=registry,ref=${{ steps.image_registry_lower.outputs.lowercase }}:buildcache-${{ inputs.branch }}
+                    cache-to: type=registry,ref=${{ steps.image_registry_lower.outputs.lowercase }}:buildcache-${{ inputs.branch }},mode=max
+                    build-args: ${{ inputs.docker_build_args }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,103 @@
+name: deploy-app
+
+# configure as reusable workflow
+on:
+    workflow_call:
+        inputs:
+            app_name:
+                required: true
+                type: string
+                description: 'name of the application in argocd'
+            image_name:
+                required: true
+                type: string
+                description: 'name of the image'
+            username:
+                required: true
+                type: string
+                description: 'username to push the image can use github.actor'
+            branch:
+                required: true
+                type: string
+                description: 'name of the branch can use github.ref_name'
+            infra_repository:
+                required: true
+                type: string
+                description: 'repository of the infra project'
+            infra_main_branch:
+                required: false
+                type: string
+                default: master
+                description: 'default branch for the infra repository'
+            push_name:
+                required: false
+                type: string
+                default: 'Super Bot'
+                description: 'name of the user who will push on infra repository'
+            push_mail:
+                required: false
+                type: string
+                default: 'bot@feedgy.solar'
+                description: 'mail of the user who will push on infra repository'
+            tag:
+                required: true
+                type: string
+                description: 'tag to release'
+            changelog:
+                required: true
+                type: string
+                description: 'changelog related to the release'
+        secrets:
+            repos_token:
+                required: true
+                description: 'token to have access to code and infra repository'
+
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Create a GitHub release
+                uses: ncipollo/release-action@v1
+                with:
+                    tag: ${{ inputs.tag }}
+                    name: Release ${{ inputs.tag }}
+                    body: ${{ inputs.changelog }}
+
+    deploy-app:
+        runs-on: ubuntu-latest
+        steps:
+            # get the source of the infra
+            -   uses: actions/checkout@v2
+                with:
+                    repository: ${{ inputs.infra_repository }}
+                    ref: ${{ inputs.infra_main_branch }}
+                    token: ${{ secrets.repos_token }}
+            -   uses: actions/setup-python@v2
+            -   name: "install pyyaml"
+                run: pip install pyyaml
+            -   name: "replace value version"
+                run: |
+                    cd ${{ inputs.APP_NAME }}
+                    # save a python script to replace values
+                    echo "
+                    import yaml
+                    from pathlib import Path
+                    import sys
+                    file_path = Path('values-${{ inputs.branch }}.yaml')
+                    config = yaml.safe_load(file_path.read_text())
+                    
+                    # Configuration to modify
+                    config['image']['tag'] = '${{ inputs.tag }}'
+                    
+                    file_path.write_text(yaml.dump(config))
+                    " > script.py
+                    python script.py
+                    
+                    # push the modification
+                    git add values-${{ inputs.branch }}.yaml
+                    git config --local user.email "${{ inputs.push_mail }}"
+                    git config --local user.name "${{ inputs.push_name }}"
+                    git commit -m "upgrade ${{ inputs.APP_NAME }} on ${{ inputs.branch }} environment to ${{ inputs.tag }}"
+                    git push

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -2,39 +2,39 @@ name: merge
 
 # configure as reusable workflow
 on:
-  workflow_call:
-    inputs:
-      target_branch:
-        required: true
-        type: string
-      source_branch:
-        required: true
-        type: string
-      bot_name:
-        required: false
-        type: string
-        default: "Super Bot"
-      bot_mail:
-        required: false
-        type: string
-        default: bot@feedgy.solar
-    secrets:
-      ACCESS_TOKEN:
-        required: true
-        description: "token to have access to code repository and registry (passed by caller workflow)"
+    workflow_call:
+        inputs:
+            target_branch:
+                required: true
+                type: string
+            source_branch:
+                required: true
+                type: string
+            bot_name:
+                required: false
+                type: string
+                default: "Super Bot"
+            bot_mail:
+                required: false
+                type: string
+                default: bot@feedgy.solar
+        secrets:
+            ACCESS_TOKEN:
+                required: true
+                description: "token to have access to code repository and registry (passed by caller workflow)"
 
 jobs:
-  merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ inputs.target_branch }}
-          token: ${{ secrets.ACCESS_TOKEN }}
-          fetch-depth: 0
-      - name: "merge branch"
-        run: |
-          git config --local user.email '${{ inputs.bot_mail }}'
-          git config --local user.name '${{ inputs.bot_name }}'
-          git merge origin/${{ inputs.source_branch }} --no-ff --no-edit
-          git push
+    merge:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    ref: ${{ inputs.target_branch }}
+                    token: ${{ secrets.ACCESS_TOKEN }}
+                    fetch-depth: 0
+            -   name: "merge branch"
+                run: |
+                    git config --local user.email '${{ inputs.bot_mail }}'
+                    git config --local user.name '${{ inputs.bot_name }}'
+                    git merge origin/${{ inputs.source_branch }} --no-ff --no-edit
+                    git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,216 +2,126 @@ name: release
 
 # configure as reusable workflow
 on:
-  workflow_call:
-    inputs:
-      app_name:
-        required: true
-        type: string
-        description: 'name of the application in argocd'
-      registry:
-        required: false
-        type: string
-        default: 'ghcr.io'
-        description: 'registry to push and get the image'
-      image_name:
-        required: true
-        type: string
-        description: 'name of the image'
-      docker_context:
-        required: false
-        type: string 
-        default: .
-        description: 'context of build for docker'
-      docker_build_args:
-        required: false
-        type: string
-        description: 'docker build args formated in multiline string with |'
-      dockerfile_path: 
-        required: false
-        type: string 
-        default: ./Dockerfile
-        description: 'location to get the Dockerfile for the build'
-      username:
-        required: true
-        type: string
-        description: 'username to push the image can use github.actor'
-      pre_release_branches: 
-        required: false
-        type: string
-        default: staging
-        description: 'comma separated list of pre release branches'
-      release_branches:
-        required: false
-        type: string
-        default: production
-        description: 'comma separated list of release branches'
-      branch:
-        required: true
-        type: string 
-        description: 'name of the branch can use github.ref_name'
-      infra_repository:
-        required: true
-        type: string
-        description: 'repository of the infra project'
-      infra_main_branch: 
-        required: false
-        type: string
-        default: master
-        description: 'default branch for the infra repository'
-      push_name:
-        required: false
-        type: string
-        default: 'Super Bot'
-        description: 'name of the user who will push on infra repository'
-      push_mail:
-        required: false
-        type: string
-        default: 'bot@feedgy.solar'
-        description: 'mail of the user who will push on infra repository'
-      dry_run: 
-        required: false
-        type: boolean
-        default: false
-        description: 'build only with the new version of tag'
-    secrets:
-      registry_token:
-        required: true
-        description: 'token to have access to registry'
-      repos_token: 
-        required: true
-        description: 'token to have access to code and infra repository'
+    workflow_call:
+        inputs:
+            app_name:
+                required: true
+                type: string
+                description: 'name of the application in argocd'
+            registry:
+                required: false
+                type: string
+                default: 'ghcr.io'
+                description: 'registry to push and get the image'
+            image_name:
+                required: true
+                type: string
+                description: 'name of the image'
+            docker_context:
+                required: false
+                type: string
+                default: .
+                description: 'context of build for docker'
+            docker_build_args:
+                required: false
+                type: string
+                description: 'docker build args formated in multiline string with |'
+            dockerfile_path:
+                required: false
+                type: string
+                default: ./Dockerfile
+                description: 'location to get the Dockerfile for the build'
+            username:
+                required: true
+                type: string
+                description: 'username to push the image can use github.actor'
+            pre_release_branches:
+                required: false
+                type: string
+                default: staging
+                description: 'comma separated list of pre release branches'
+            release_branches:
+                required: false
+                type: string
+                default: production
+                description: 'comma separated list of release branches'
+            branch:
+                required: true
+                type: string
+                description: 'name of the branch can use github.ref_name'
+            infra_repository:
+                required: true
+                type: string
+                description: 'repository of the infra project'
+            infra_main_branch:
+                required: false
+                type: string
+                default: master
+                description: 'default branch for the infra repository'
+            push_name:
+                required: false
+                type: string
+                default: 'Super Bot'
+                description: 'name of the user who will push on infra repository'
+            push_mail:
+                required: false
+                type: string
+                default: 'bot@feedgy.solar'
+                description: 'mail of the user who will push on infra repository'
+            dry_run:
+                required: false
+                type: boolean
+                default: false
+                description: 'build only with the new version of tag'
+        secrets:
+            registry_token:
+                required: true
+                description: 'token to have access to registry'
+            repos_token:
+                required: true
+                description: 'token to have access to code and infra repository'
 
 
 jobs:
-  tag:
-    runs-on: ubuntu-latest
-    outputs:
-      new_tag: ${{ steps.tag_version.outputs.new_tag }}
-      new_version: ${{ steps.tag_version.outputs.new_version }}
-      changelog: ${{ steps.tag_version.outputs.changelog }}
-    steps:
-      - uses: actions/checkout@v2
+    tag:
+        uses: ./tag.yml
         with:
-          token: ${{ secrets.repos_token}}
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.0
+            pre_release_branches: ${{ inputs.pre_release_branches }}
+            release_branches: ${{ inputs.release_branches }}
+            dry_run: ${{ inputs.dry_run }}
+        secrets:
+            repos_token: ${{ secrets.repos_token }}
+    build:
+        uses: ./build-docker.yml
+        needs:
+            - tag
         with:
-          # use PAT token to enable to merge production in master at release
-          github_token: ${{ secrets.repos_token}}
-          release_branches: ${{ inputs.release_branches }}
-          pre_release_branches: ${{ inputs.pre_release_branches }}
-          dry_run: ${{ inputs.dry_run }}
-  deploy-docker:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs:
-      - tag
-    outputs:
-      pushed_tag: ${{needs.tag.outputs.new_tag}}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - id: image_registry_lower
-        uses: ASzc/change-string-case-action@v2
+            registry: ${{ inputs.registry }}
+            image_name: ${{ inputs.image_name }}
+            docker_context: ${{ inputs.docker_context }}
+            docker_build_args: ${{ inputs.docker_build_args }}
+            dockerfile_path: ${{ inputs.dockerfile_path }}
+            username: ${{ inputs.username }}
+            branch: ${{ inputs.branch }}
+            tag: ${{ needs.tag.new_tag }}
+            dry_run: ${{ inputs.dry_run }}
+        secrets:
+            registry_token: ${{ source.registry_token }}
+    deploy-and-release:
+        uses: ./deploy-app.yml
+        needs:
+            - tag
+            - build
         with:
-          string: ${{ inputs.registry }}/${{ inputs.IMAGE_NAME }}
-      # Set docker driver to permit cache
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          driver: docker-container
-          driver-opts: |
-            image=moby/buildkit:master
-            network=host
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ inputs.registry }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
-        with:
-          registry: ${{ inputs.registry }}
-          username: ${{ inputs.username }}
-          password: ${{ secrets.registry_token }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681
-        with:
-          github-token: ${{ secrets.registry_token }}
-          images: ${{ steps.image_registry_lower.outputs.lowercase }}
-          tags: |
-            type=semver, pattern={{raw}}, value=${{needs.tag.outputs.new_tag}}
-            type=ref, event=branch
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        id: build
-        with:
-          context: ${{ inputs.docker_context }}
-          push: ${{ inputs.dry_run == false }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          file: ${{ inputs.dockerfile_path }}
-          cache-from: type=registry,ref=${{ steps.image_registry_lower.outputs.lowercase }}:buildcache-${{ inputs.branch }}
-          cache-to: type=registry,ref=${{ steps.image_registry_lower.outputs.lowercase }}:buildcache-${{ inputs.branch }},mode=max
-          build-args: ${{ inputs.docker_build_args }}
-  release:
-    runs-on: ubuntu-latest
-    if: ${{ inputs.dry_run == false }}
-    needs: tag
-    steps:
-      - uses: actions/checkout@v2
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ needs.tag.outputs.new_version }}
-          name: Release ${{ needs.tag.outputs.new_version }}
-          body: ${{ needs.tag.outputs.changelog }}
-
-  deploy-app:
-    runs-on: ubuntu-latest
-    if: ${{ inputs.dry_run == false }}
-    needs:
-      - deploy-docker
-    steps:
-      # get the source of the infra
-      - uses: actions/checkout@v2
-        with:
-          repository: ${{ inputs.infra_repository }}
-          ref: ${{ inputs.infra_main_branch }}
-          token: ${{ secrets.repos_token }}
-      - uses: actions/setup-python@v2
-      - name: "install pyyaml"
-        run: pip install pyyaml 
-      - name: "replace value version"
-        run: |
-          cd ${{ inputs.APP_NAME }}
-          # save a python script to replace values
-          echo "
-          import yaml
-          from pathlib import Path
-          import sys
-          file_path = Path('values-${{ inputs.branch }}.yaml')
-          config = yaml.safe_load(file_path.read_text())
-
-          # Configuration to modify
-          config['image']['tag'] = '${{ needs.deploy-docker.outputs.pushed_tag }}'
-
-          file_path.write_text(yaml.dump(config))
-          " > script.py
-          python script.py
-
-          # push the modification
-          git add values-${{ inputs.branch }}.yaml
-          git config --local user.email "${{ inputs.push_mail }}"
-          git config --local user.name "${{ inputs.push_name }}"
-          git commit -m "upgrade ${{ inputs.APP_NAME }} on ${{ inputs.branch }} environment to ${{ needs.deploy-docker.outputs.pushed_tag }}"
-          git push
+            app_name: ${{ inputs.app_name }}
+            image_name: ${{ inputs.image_name }}
+            username: ${{ inputs.username }}
+            branch: ${{ inputs.branch }}
+            infra_repository: ${{ inputs.infra_repository }}
+            infra_main_branch: ${{ inputs.infra_main_branch }}
+            push_name: ${{ inputs.push_name }}
+            push_mail: ${{ inputs.push_mail }}
+            tag: ${{ needs.build.outputs.tag }}
+            changelog: ${{ needs.tag.outputs.changelog }}
+        secrets:
+            repos_token: ${{ secrets.repos_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ on:
 
 jobs:
     tag:
-        uses: ./tag.yml
+        uses: ./.github/workflows/tag.yml
         with:
             pre_release_branches: ${{ inputs.pre_release_branches }}
             release_branches: ${{ inputs.release_branches }}
@@ -92,7 +92,7 @@ jobs:
         secrets:
             repos_token: ${{ secrets.repos_token }}
     build:
-        uses: ./build-docker.yml
+        uses: ./.github/workflows/build-docker.yml
         needs:
             - tag
         with:
@@ -108,7 +108,7 @@ jobs:
         secrets:
             registry_token: ${{ source.registry_token }}
     deploy-and-release:
-        uses: ./deploy-app.yml
+        uses: ./.github/workflows/deploy-app.yml
         needs:
             - tag
             - build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,44 +84,134 @@ on:
 
 jobs:
     tag:
-        uses: ./.github/workflows/tag.yml
-        with:
-            pre_release_branches: ${{ inputs.pre_release_branches }}
-            release_branches: ${{ inputs.release_branches }}
-            dry_run: ${{ inputs.dry_run }}
-        secrets:
-            repos_token: ${{ secrets.repos_token }}
-    build:
-        uses: ./.github/workflows/build-docker.yml
+        runs-on: ubuntu-latest
+        outputs:
+            new_tag: ${{ steps.tag_version.outputs.new_tag }}
+            new_version: ${{ steps.tag_version.outputs.new_version }}
+            changelog: ${{ steps.tag_version.outputs.changelog }}
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    token: ${{ secrets.repos_token}}
+            -   name: Bump version and push tag
+                id: tag_version
+                uses: mathieudutour/github-tag-action@v6.0
+                with:
+                    # use PAT token to enable to merge production in master at release
+                    github_token: ${{ secrets.repos_token}}
+                    release_branches: ${{ inputs.release_branches }}
+                    pre_release_branches: ${{ inputs.pre_release_branches }}
+                    dry_run: ${{ inputs.dry_run }}
+    deploy-docker:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
         needs:
             - tag
-        with:
-            registry: ${{ inputs.registry }}
-            image_name: ${{ inputs.image_name }}
-            docker_context: ${{ inputs.docker_context }}
-            docker_build_args: ${{ inputs.docker_build_args }}
-            dockerfile_path: ${{ inputs.dockerfile_path }}
-            username: ${{ inputs.username }}
-            branch: ${{ inputs.branch }}
-            tag: ${{ needs.tag.new_tag }}
-            dry_run: ${{ inputs.dry_run }}
-        secrets:
-            registry_token: ${{ source.registry_token }}
-    deploy-and-release:
-        uses: ./.github/workflows/deploy-app.yml
+        outputs:
+            pushed_tag: ${{needs.tag.outputs.new_tag}}
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v2
+
+            -   id: image_registry_lower
+                uses: ASzc/change-string-case-action@v2
+                with:
+                    string: ${{ inputs.registry }}/${{ inputs.IMAGE_NAME }}
+            # Set docker driver to permit cache
+            -   name: Set up Docker Buildx
+                uses: docker/setup-buildx-action@v1
+                with:
+                    driver: docker-container
+                    driver-opts: |
+                        image=moby/buildkit:master
+                        network=host
+            # Login against a Docker registry except on PR
+            # https://github.com/docker/login-action
+            -   name: Log into registry ${{ inputs.registry }}
+                if: github.event_name != 'pull_request'
+                uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+                with:
+                    registry: ${{ inputs.registry }}
+                    username: ${{ inputs.username }}
+                    password: ${{ secrets.registry_token }}
+
+            # Extract metadata (tags, labels) for Docker
+            # https://github.com/docker/metadata-action
+            -   name: Extract Docker metadata
+                id: meta
+                uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681
+                with:
+                    github-token: ${{ secrets.registry_token }}
+                    images: ${{ steps.image_registry_lower.outputs.lowercase }}
+                    tags: |
+                        type=semver, pattern={{raw}}, value=${{needs.tag.outputs.new_tag}}
+                        type=ref, event=branch
+            # Build and push Docker image with Buildx (don't push on PR)
+            # https://github.com/docker/build-push-action
+            -   name: Build and push Docker image
+                uses: docker/build-push-action@v2
+                id: build
+                with:
+                    context: ${{ inputs.docker_context }}
+                    push: ${{ inputs.dry_run == false }}
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
+                    file: ${{ inputs.dockerfile_path }}
+                    cache-from: type=registry,ref=${{ steps.image_registry_lower.outputs.lowercase }}:buildcache-${{ inputs.branch }}
+                    cache-to: type=registry,ref=${{ steps.image_registry_lower.outputs.lowercase }}:buildcache-${{ inputs.branch }},mode=max
+                    build-args: ${{ inputs.docker_build_args }}
+    release:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.dry_run == false }}
+        needs: tag
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Create a GitHub release
+                uses: ncipollo/release-action@v1
+                with:
+                    tag: ${{ needs.tag.outputs.new_version }}
+                    name: Release ${{ needs.tag.outputs.new_version }}
+                    body: ${{ needs.tag.outputs.changelog }}
+
+    deploy-app:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.dry_run == false }}
         needs:
-            - tag
-            - build
-        with:
-            app_name: ${{ inputs.app_name }}
-            image_name: ${{ inputs.image_name }}
-            username: ${{ inputs.username }}
-            branch: ${{ inputs.branch }}
-            infra_repository: ${{ inputs.infra_repository }}
-            infra_main_branch: ${{ inputs.infra_main_branch }}
-            push_name: ${{ inputs.push_name }}
-            push_mail: ${{ inputs.push_mail }}
-            tag: ${{ needs.build.outputs.tag }}
-            changelog: ${{ needs.tag.outputs.changelog }}
-        secrets:
-            repos_token: ${{ secrets.repos_token }}
+            - deploy-docker
+        steps:
+            # get the source of the infra
+            -   uses: actions/checkout@v2
+                with:
+                    repository: ${{ inputs.infra_repository }}
+                    ref: ${{ inputs.infra_main_branch }}
+                    token: ${{ secrets.repos_token }}
+            -   uses: actions/setup-python@v2
+            -   name: "install pyyaml"
+                run: pip install pyyaml
+            -   name: "replace value version"
+                run: |
+                    cd ${{ inputs.APP_NAME }}
+                    # save a python script to replace values
+                    echo "
+                    import yaml
+                    from pathlib import Path
+                    import sys
+                    file_path = Path('values-${{ inputs.branch }}.yaml')
+                    config = yaml.safe_load(file_path.read_text())
+                    
+                    # Configuration to modify
+                    config['image']['tag'] = '${{ needs.deploy-docker.outputs.pushed_tag }}'
+                    
+                    file_path.write_text(yaml.dump(config))
+                    " > script.py
+                    python script.py
+                    
+                    # push the modification
+                    git add values-${{ inputs.branch }}.yaml
+                    git config --local user.email "${{ inputs.push_mail }}"
+                    git config --local user.name "${{ inputs.push_name }}"
+                    git commit -m "upgrade ${{ inputs.APP_NAME }} on ${{ inputs.branch }} environment to ${{ needs.deploy-docker.outputs.pushed_tag }}"
+                    git push

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,51 @@
+name: tag
+
+# configure as reusable workflow
+on:
+    workflow_call:
+        inputs:
+            pre_release_branches:
+                required: false
+                type: string
+                default: staging
+                description: 'comma separated list of pre release branches'
+            release_branches:
+                required: false
+                type: string
+                default: production
+                description: 'comma separated list of release branches'
+            dry_run:
+                required: false
+                type: boolean
+                default: false
+                description: 'build only with the new version of tag'
+        secrets:
+            repos_token:
+                required: true
+                description: 'token to have access to code and infra repository'
+        outputs:
+            new_tag: ${{ jobs.tag.outputs.new_tag }}
+            new_version: ${{ jobs.tag.outputs.new_version }}
+            changelog: ${{ jobs.tag.outputs.changelog }}
+
+
+jobs:
+    tag:
+        runs-on: ubuntu-latest
+        outputs:
+            new_tag: ${{ steps.tag_version.outputs.new_tag }}
+            new_version: ${{ steps.tag_version.outputs.new_version }}
+            changelog: ${{ steps.tag_version.outputs.changelog }}
+        steps:
+            -   uses: actions/checkout@v2
+                with:
+                    token: ${{ secrets.repos_token}}
+            -   name: Bump version and push tag
+                id: tag_version
+                uses: mathieudutour/github-tag-action@v6.0
+                with:
+                    # use PAT token to enable to merge production in master at release
+                    github_token: ${{ secrets.repos_token}}
+                    release_branches: ${{ inputs.release_branches }}
+                    pre_release_branches: ${{ inputs.pre_release_branches }}
+                    dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
spliting (release.yml) into multiples workflows :
    - tag : tagging with specific action
    - build-docker : build docker image and push it
    - deploy-app : release github + deploy app on infra repository

release.yml will call these reusable workflows to not break descending compatibility