### PR TITLE
ci,typescript: set node memory for build stage

### DIFF
--- a/.github/workflows/ci.typescript.yml
+++ b/.github/workflows/ci.typescript.yml
@@ -63,6 +63,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Application
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
         run: yarn build
 
   test:


### PR DESCRIPTION
Tested in https://github.com/Feedgy/front-office/actions/runs/12671068991/job/35312091024
