### PR TITLE
ci: add possibility to run custom audit commands

### DIFF
--- a/.github/workflows/ci.typescript.yml
+++ b/.github/workflows/ci.typescript.yml
@@ -53,6 +53,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: "yarn"
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
       - name: Security Check
         run: ${{ inputs.security-check-command }}
 


### PR DESCRIPTION
This PR is to address the `yarn audit` rigidity: we can not surpress know security vulnerabilities:
https://github.com/yarnpkg/yarn/issues/6669  
we need to use `audit-ci` package/command, so we need to yarn install before using it.  
