### PR TITLE
build: add pbr to install on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install pbr (fix for Bandit dependency)
+        run: pip install pbr==6.0.0
       - name: Bandit
         uses: jpetrucciani/bandit-check@main
 


### PR DESCRIPTION
Bandit fails on CI due to missing pbr module. This PR makes sure the dependency is installed before running bandit.